### PR TITLE
Refine site copy for human voice and remove em dashes

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -15,7 +15,7 @@ const {
   article = false,
 } = Astro.props;
 
-const pageTitle = title ? `${title} · ${SITE.title}` : `${SITE.title} — ${SITE.tagline}`;
+const pageTitle = title ? `${title} · ${SITE.title}` : `${SITE.title} · ${SITE.tagline}`;
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const ogImageUrl = new URL(ogImage, Astro.site);
 ---

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,7 +4,7 @@ export const SITE = {
   title: 'Josh English',
   tagline: 'Software engineer',
   description:
-    'Josh English — full-stack software engineer at AWS. Writing about software, finance, and whatever else is on my mind.',
+    'Josh English, full-stack software engineer at AWS. Writing about software, finance, and whatever else is on my mind.',
   author: 'Josh English',
   url: 'https://www.joshenglish.com',
   // Universal Analytics (UA-5317622-1) was retired in 2023. Re-add GA4 or a

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -17,7 +17,7 @@ const { title, subtitle, date, tags, author, draft, description, ogImage } =
     {
       draft && (
         <p class="draft-banner">
-          ⚠ This is a draft — published content may change.
+          ⚠ This is a draft. Published content may change.
         </p>
       )
     }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,7 +4,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout
   title="About"
-  description="About Josh English — full-stack software engineer at AWS."
+  description="About Josh English, full-stack software engineer at AWS."
 >
   <div class="wrapper prose about">
     <p class="eyebrow">~ cat about.md</p>
@@ -12,7 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <p>
       Josh is a full-stack software engineer at AWS. He didn't start out writing
-      code — he just always liked taking things apart to see how they worked, and
+      code. He just always liked taking things apart to see how they worked, and
       that eventually turned into a career. Outside of it, he's into finance,
       wrenching on motorcycles, collecting wine, and pretending to play golf.
     </p>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -17,7 +17,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
       <p class="eyebrow">~/blog $ ls -t</p>
       <h1>Blog</h1>
       <p class="lede">
-        Rantings, rumblings, and the occasional useful thing — categorized by tag.
+        Rants, ramblings, and the occasional useful thing, sorted by tag.
       </p>
     </header>
 


### PR DESCRIPTION
## Summary

Reviewed all user-facing copy across the site to ensure it reads in a natural human voice and removed every em dash.

### Em dashes removed (none remain in `src/`)
- `BaseHead.astro` — home page title separator now uses `·`, matching the inner-page format
- `consts.ts` — site description meta
- `about.astro` — meta description and bio paragraph
- `blog/index.astro` — blog lede
- `BlogPost.astro` — draft banner

### Tone
Most copy (home hero bio, About, the "Who am I?" post) already reads in a natural first-person voice, so it was left as-is rather than over-rewritten. The blog lede was the one stiff/listy spot, changed from "Rantings, rumblings, and the occasional useful thing — categorized by tag" to "Rants, ramblings, and the occasional useful thing, sorted by tag."

### Verification
`astro build` passes; all 5 pages generate cleanly.

Note: `public/cointracker/` was intentionally left untouched — it's a build artifact from an unrelated old project, not part of the site's own language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eLpn3CSbEbf7wR7P2DXnE

---
_Generated by [Claude Code](https://claude.ai/code/session_015eLpn3CSbEbf7wR7P2DXnE)_