### PR TITLE
Improve SEO: robots.txt, JSON-LD structured data, article metadata

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# https://www.joshenglish.com
+User-agent: *
+Allow: /
+
+# Legacy CRA demo deployed under /cointracker — keep it out of the index
+# so it doesn't compete as thin/duplicate content.
+Disallow: /cointracker/
+
+Sitemap: https://www.joshenglish.com/sitemap-index.xml

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,11 +1,13 @@
 ---
-import { SITE } from '../consts';
+import { SITE, SOCIAL_LINKS } from '../consts';
 
 interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
   article?: boolean;
+  publishedDate?: Date;
+  tags?: string[];
 }
 
 const {
@@ -13,11 +15,56 @@ const {
   description = SITE.description,
   ogImage = '/favicon.png',
   article = false,
+  publishedDate,
+  tags = [],
 } = Astro.props;
 
 const pageTitle = title ? `${title} · ${SITE.title}` : `${SITE.title} · ${SITE.tagline}`;
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const ogImageUrl = new URL(ogImage, Astro.site);
+const ogImageAlt = title ? `${title} — ${SITE.title}` : `${SITE.title}, ${SITE.tagline}`;
+const isHome = Astro.url.pathname === '/';
+
+// Social profiles strengthen the Person entity (knowledge-graph sameAs).
+const sameAs = SOCIAL_LINKS.filter((l) => l.href.startsWith('http')).map((l) => l.href);
+
+// Structured data (schema.org). WebSite sitewide; Person on the home page;
+// BlogPosting on articles.
+const jsonLd: Record<string, unknown>[] = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE.title,
+    url: SITE.url,
+    description: SITE.description,
+  },
+];
+
+if (article && publishedDate) {
+  jsonLd.push({
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description,
+    datePublished: publishedDate.toISOString(),
+    author: { '@type': 'Person', name: SITE.author, url: SITE.url },
+    publisher: { '@type': 'Person', name: SITE.author, url: SITE.url },
+    image: ogImageUrl.href,
+    url: canonical.href,
+    mainEntityOfPage: canonical.href,
+    ...(tags.length ? { keywords: tags.join(', ') } : {}),
+  });
+} else if (isHome) {
+  jsonLd.push({
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: SITE.author,
+    url: SITE.url,
+    jobTitle: SITE.tagline,
+    description: SITE.description,
+    sameAs,
+  });
+}
 ---
 
 <meta charset="utf-8" />
@@ -43,7 +90,16 @@ const ogImageUrl = new URL(ogImage, Astro.site);
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={ogImageUrl} />
+<meta property="og:image:alt" content={ogImageAlt} />
 <meta property="og:site_name" content={SITE.title} />
+<meta property="og:locale" content="en_US" />
+{
+  article && publishedDate && (
+    <meta property="article:published_time" content={publishedDate.toISOString()} />
+  )
+}
+{article && <meta property="article:author" content={SITE.author} />}
+{article && tags.map((tag) => <meta property="article:tag" content={tag} />)}
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
@@ -51,7 +107,14 @@ const ogImageUrl = new URL(ogImage, Astro.site);
 <meta property="twitter:title" content={pageTitle} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={ogImageUrl} />
+<meta property="twitter:image:alt" content={ogImageAlt} />
+<meta property="twitter:site" content="@joshenglish" />
 <meta property="twitter:creator" content="@joshenglish" />
+
+<!-- Structured data -->
+{jsonLd.map((entry) => (
+  <script type="application/ld+json" set:html={JSON.stringify(entry)} />
+))}
 
 <!-- No-flash theme: set data-theme before first paint, and re-apply after
      Astro view transitions swap the document. -->

--- a/src/content/blog/who-am-i.md
+++ b/src/content/blog/who-am-i.md
@@ -1,6 +1,7 @@
 ---
 title: "Who am I?"
 date: 2024-09-26
+description: "A quick introduction — who Josh English is and isn't: a full-stack engineer at AWS, OMSCS student, motorcycle rider, and problem solver, and what to expect from this blog."
 tags: [self]
 ---
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,9 +12,12 @@ interface Props {
   description?: string;
   ogImage?: string;
   article?: boolean;
+  publishedDate?: Date;
+  tags?: string[];
 }
 
-const { title, description, ogImage, article } = Astro.props;
+const { title, description, ogImage, article, publishedDate, tags } =
+  Astro.props;
 ---
 
 <!doctype html>
@@ -25,6 +28,8 @@ const { title, description, ogImage, article } = Astro.props;
       description={description}
       ogImage={ogImage}
       article={article}
+      publishedDate={publishedDate}
+      tags={tags}
     />
     <ClientRouter />
   </head>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 import FormattedDate from '../components/FormattedDate.astro';
+import { tagPath } from '../utils/tags';
 import type { CollectionEntry } from 'astro:content';
 
 interface Props {
@@ -41,7 +42,11 @@ const { title, subtitle, date, tags, author, draft, description, ogImage } =
         tags.length > 0 && (
           <ul class="tags">
             {tags.map((tag) => (
-              <li class="tag">#{tag}</li>
+              <li>
+                <a class="tag" href={tagPath(tag)}>
+                  #{tag}
+                </a>
+              </li>
             ))}
           </ul>
         )
@@ -94,6 +99,7 @@ const { title, subtitle, date, tags, author, draft, description, ogImage } =
     margin: var(--space-s) 0 0;
   }
   .tag {
+    display: inline-block;
     font-family: var(--font-mono);
     font-size: var(--step--1);
     color: var(--accent);
@@ -101,6 +107,11 @@ const { title, subtitle, date, tags, author, draft, description, ogImage } =
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     padding: 0.1rem 0.55rem;
+    transition: border-color var(--dur) var(--ease);
+  }
+  .tag:hover {
+    border-color: var(--accent);
+    text-decoration: none;
   }
   .draft-banner {
     background: color-mix(in srgb, var(--accent) 14%, var(--bg));

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -12,7 +12,14 @@ const { title, subtitle, date, tags, author, draft, description, ogImage } =
   post.data;
 ---
 
-<BaseLayout title={title} description={description} ogImage={ogImage} article>
+<BaseLayout
+  title={title}
+  description={description}
+  ogImage={ogImage}
+  article
+  publishedDate={date}
+  tags={tags}
+>
   <article class="wrapper post">
     {
       draft && (

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -17,7 +17,8 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
       <p class="eyebrow">~/blog $ ls -t</p>
       <h1>Blog</h1>
       <p class="lede">
-        Rants, ramblings, and the occasional useful thing, sorted by tag.
+        Rants, ramblings, and the occasional useful thing.
+        <a href="/blog/tags/">Browse by tag →</a>
       </p>
     </header>
 

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,49 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import PostListItem from '../../../components/PostListItem.astro';
+import { getTags } from '../../../utils/tags';
+
+export async function getStaticPaths() {
+  const tags = await getTags();
+  return [...tags.values()].map(({ slug, tag, posts }) => ({
+    params: { tag: slug },
+    props: { tag, posts },
+  }));
+}
+
+const { tag, posts } = Astro.props;
+const count = posts.length;
+---
+
+<BaseLayout
+  title={`#${tag}`}
+  description={`${count} post${count === 1 ? '' : 's'} tagged “${tag}” by Josh English.`}
+>
+  <div class="wrapper">
+    <header class="page-head">
+      <p class="eyebrow">~/blog $ grep -l '#{tag}' *</p>
+      <h1>#{tag}</h1>
+      <p class="lede">
+        {count} post{count === 1 ? '' : 's'} tagged <strong>{tag}</strong>.
+        <a href="/blog/tags/">All tags →</a>
+      </p>
+    </header>
+
+    <div class="post-list">
+      {posts.map((post) => <PostListItem post={post} />)}
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .page-head {
+    margin-bottom: var(--space-l);
+  }
+  .page-head h1 {
+    margin: var(--space-2xs) 0;
+  }
+  .lede {
+    color: var(--text-muted);
+    margin: 0;
+  }
+</style>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,0 +1,80 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { getTags, tagPath } from '../../../utils/tags';
+
+const tags = [...(await getTags()).values()]
+  .map(({ slug, tag, posts }) => ({ slug, tag, count: posts.length }))
+  .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+---
+
+<BaseLayout
+  title="Tags"
+  description="Browse posts by topic — every tag on Josh English's blog."
+>
+  <div class="wrapper">
+    <header class="page-head">
+      <p class="eyebrow">~/blog $ ls tags/</p>
+      <h1>Tags</h1>
+      <p class="lede">Browse posts by topic.</p>
+    </header>
+
+    {
+      tags.length === 0 ? (
+        <p class="lede">No tags yet.</p>
+      ) : (
+        <ul class="tag-cloud">
+          {tags.map((t) => (
+            <li>
+              <a class="tag" href={tagPath(t.tag)}>
+                #{t.tag}
+                <span class="count">{t.count}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </div>
+</BaseLayout>
+
+<style>
+  .page-head {
+    margin-bottom: var(--space-l);
+  }
+  .page-head h1 {
+    margin: var(--space-2xs) 0;
+  }
+  .lede {
+    color: var(--text-muted);
+    margin: 0;
+  }
+  .tag-cloud {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+    padding: 0;
+    margin: 0;
+  }
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-family: var(--font-mono);
+    font-size: var(--step--1);
+    color: var(--accent);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.2rem 0.6rem;
+    transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
+  }
+  .tag:hover {
+    border-color: var(--accent);
+    text-decoration: none;
+  }
+  .count {
+    color: var(--text-muted);
+    font-size: 0.78em;
+  }
+</style>

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,0 +1,45 @@
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+
+export type BlogPost = CollectionEntry<'blog'>;
+
+/** URL-safe slug for a tag (shared by routing and link generation). */
+export function tagSlug(tag: string): string {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Canonical path to a tag's archive page. */
+export function tagPath(tag: string): string {
+  return `/blog/tags/${tagSlug(tag)}/`;
+}
+
+/** All published (non-draft) posts, newest first. */
+export async function getPublishedPosts(): Promise<BlogPost[]> {
+  return (await getCollection('blog', ({ data }) => !data.draft)).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  );
+}
+
+export type TagEntry = { slug: string; tag: string; posts: BlogPost[] };
+
+/**
+ * Map of tag slug -> { display label, posts } across all published posts.
+ * The first-seen spelling of a tag wins as the display label.
+ */
+export async function getTags(): Promise<Map<string, TagEntry>> {
+  const posts = await getPublishedPosts();
+  const map = new Map<string, TagEntry>();
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const slug = tagSlug(tag);
+      if (!slug) continue;
+      if (!map.has(slug)) map.set(slug, { slug, tag, posts: [] });
+      map.get(slug)!.posts.push(post);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
- Add /robots.txt with sitemap pointer; disallow legacy /cointracker/ to
  avoid thin/duplicate content competing in the index
- Emit JSON-LD: WebSite sitewide, Person (with social sameAs) on home,
  BlogPosting on posts for rich-result eligibility
- Add article:published_time/author/tag, og:image:alt, og:locale,
  twitter:site/image:alt for richer link previews and freshness signals
- Give the existing post a unique meta description (was falling back to
  the generic site description)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TDpVCjiHegf3V515WNSfYm