### PR TITLE
Remove em dashes and add AGENT.md voice guidelines

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,15 @@
+# Agent Guidelines
+
+Guidance for AI agents and contributors working on this site.
+
+## Voice and tone
+
+Write in a real, human voice. Keep copy direct, plain, and conversational, the way Josh would actually talk. Avoid stiff, corporate, or marketing-speak phrasing.
+
+## Punctuation
+
+- **Never use em dashes (—).** Rewrite the sentence instead. Use a period, comma, colon, or parentheses depending on what reads naturally.
+- Avoid en dashes (–) in prose for the same reason; use plain words like "to" for ranges.
+- Prefer short, clear sentences over long ones stitched together with dashes.
+
+When in doubt, read the sentence out loud. If it doesn't sound like something a person would say, rewrite it.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,7 +2,7 @@
 User-agent: *
 Allow: /
 
-# Legacy CRA demo deployed under /cointracker — keep it out of the index
+# Legacy CRA demo deployed under /cointracker, keep it out of the index
 # so it doesn't compete as thin/duplicate content.
 Disallow: /cointracker/
 

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -22,7 +22,7 @@ const {
 const pageTitle = title ? `${title} · ${SITE.title}` : `${SITE.title} · ${SITE.tagline}`;
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const ogImageUrl = new URL(ogImage, Astro.site);
-const ogImageAlt = title ? `${title} — ${SITE.title}` : `${SITE.title}, ${SITE.tagline}`;
+const ogImageAlt = title ? `${title}: ${SITE.title}` : `${SITE.title}, ${SITE.tagline}`;
 const isHome = Astro.url.pathname === '/';
 
 // Social profiles strengthen the Person entity (knowledge-graph sameAs).

--- a/src/content/blog/who-am-i.md
+++ b/src/content/blog/who-am-i.md
@@ -1,7 +1,7 @@
 ---
 title: "Who am I?"
 date: 2024-09-26
-description: "A quick introduction — who Josh English is and isn't: a full-stack engineer at AWS, OMSCS student, motorcycle rider, and problem solver, and what to expect from this blog."
+description: "A quick introduction to who Josh English is and isn't: a full-stack engineer at AWS, OMSCS student, motorcycle rider, and problem solver, and what to expect from this blog."
 tags: [self]
 ---
 

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -9,7 +9,7 @@ const tags = [...(await getTags()).values()]
 
 <BaseLayout
   title="Tags"
-  description="Browse posts by topic — every tag on Josh English's blog."
+  description="Browse posts by topic. Every tag on Josh English's blog."
 >
   <div class="wrapper">
     <header class="page-head">


### PR DESCRIPTION
## Summary

A few em dashes crept back into site copy via the recent SEO and tag-archive commits (all introduced after the earlier "remove em dashes" pass). This removes them and documents the convention so it stays gone.

## Changes

- `public/robots.txt` — comment now uses a comma
- `src/pages/blog/tags/index.astro` — meta description split into two sentences
- `src/content/blog/who-am-i.md` — reworded to "A quick introduction to who..."
- `src/components/BaseHead.astro` — og image alt now uses a colon
- `AGENT.md` (new) — documents the convention: write in a real human voice and never use em dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JKnriFTCz72Gtpig23swf

---
_Generated by [Claude Code](https://claude.ai/code/session_013JKnriFTCz72Gtpig23swf)_