### PR TITLE
Add Google Analytics tracking with view transitions support

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -71,6 +71,27 @@ if (article && publishedDate) {
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="generator" content={Astro.generator} />
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-00TGHBNECJ"></script>
+<script is:inline>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+  gtag('config', 'G-00TGHBNECJ');
+
+  // View transitions swap the document without a full reload, so send a
+  // page_view manually on each client-side navigation.
+  document.addEventListener('astro:after-swap', () => {
+    gtag('event', 'page_view', {
+      page_path: location.pathname + location.search,
+      page_location: location.href,
+      page_title: document.title,
+    });
+  });
+</script>
+
 <title>{pageTitle}</title>
 <meta name="title" content={pageTitle} />
 <meta name="description" content={description} />


### PR DESCRIPTION
## Summary
This PR adds Google Analytics (GA4) tracking to the site with proper support for Astro's view transitions feature.

## Key Changes
- Integrated Google Analytics 4 (gtag.js) script with tracking ID `G-00TGHBNECJ`
- Added custom event listener for `astro:after-swap` to manually track page views during client-side navigation
- Configured page view tracking to capture pathname, full URL, and page title for each navigation event

## Implementation Details
The implementation addresses a specific requirement of Astro's view transitions: since view transitions swap the document without a full page reload, the standard GA4 initialization alone is insufficient. The custom `astro:after-swap` event listener ensures that page view events are properly tracked for each client-side navigation, maintaining accurate analytics data across the entire user journey.

https://claude.ai/code/session_013tK651VaBE8AhJo7nKuAJj