### PR TITLE
Shorten latest blog post title

### DIFF
--- a/src/content/blog/panigale-gear-indicator-fix.md
+++ b/src/content/blog/panigale-gear-indicator-fix.md
@@ -1,5 +1,5 @@
 ---
-title: "My 2025 Panigale V4S showed a dash where the N should be"
+title: "When my Panigale V4S lost its N"
 description: "My 2025 Ducati Panigale V4S started showing a dash instead of an N for neutral, which killed the quick shifter too. Here is what went wrong and how Ducati fixed it."
 date: 2026-06-23
 tags: ["motorcycles", "ducati", "panigale"]


### PR DESCRIPTION
## Summary

Shortens the title of the latest blog post (the 2026-06-23 Panigale gear-indicator post), which was running long at ~56 characters.

- **Before:** `My 2025 Panigale V4S showed a dash where the N should be`
- **After:** `When my Panigale V4S lost its N`

The bike name stays in the title for SEO, and the "2025 Ducati / dash instead of N" detail still lives in the post's `description` and `tags`, so nothing is lost by trimming. The `description` field is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdSkCTZHziUd6Adhk7k9Vx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdSkCTZHziUd6Adhk7k9Vx)_